### PR TITLE
upgrade gradio flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
+user_feedback

--- a/README.md
+++ b/README.md
@@ -4,12 +4,12 @@ emoji: 🚀
 colorFrom: blue
 colorTo: gray
 sdk: gradio
-sdk_version: 5.8.0
+sdk_version: 5.10.0
 app_file: app/app.py
 pinned: false
 ---
 
-# Feel 
+# Feel
 
 This is a project to create a continuous training application.
 

--- a/app/app.py
+++ b/app/app.py
@@ -141,7 +141,6 @@ def wrangle_like_data(x: gr.LikeData, history) -> DataFrame:
 
     output_data = []
     for idx, message in enumerate(history):
-        print(message)
         if isinstance(message, gr.ChatMessage):
             message = message.__dict__
         if idx == liked_index:

--- a/app/app.py
+++ b/app/app.py
@@ -215,18 +215,6 @@ def wrangle_edit_data(
         return history
 
 
-def wrangle_undo_data(
-    x: gr.UndoData, history: list, dataframe: DataFrame, session_id: str
-) -> list:
-    """Undo the last turn and add negative feedback on the original message
-
-    Return the history without the last turn"""
-    add_fake_like_data(history, session_id)
-    # Return the history without the last turn
-    history = history[:-2]
-    return history, update_dataframe(dataframe, history)
-
-
 def wrangle_retry_data(
     x: gr.RetryData, history: list, dataframe: DataFrame, session_id: str
 ) -> list:
@@ -331,12 +319,6 @@ with gr.Blocks(css=css) as demo:
         inputs=[chatbot, dataframe, session_id],
         outputs=[chatbot],
     ).then(update_dataframe, inputs=[dataframe, chatbot], outputs=[dataframe])
-
-    chatbot.undo(
-        fn=wrangle_undo_data,
-        inputs=[chatbot, dataframe, session_id],
-        outputs=[chatbot, dataframe],
-    )
 
     submit_btn.click(
         fn=submit_conversation,

--- a/app/app.py
+++ b/app/app.py
@@ -83,11 +83,11 @@ def _process_content(content) -> str | list[str]:
     return content
 
 
-def remove_last_message(history: list) -> list:
+def remove_last_message(x: gr.UndoData, history: list) -> list:
     return history[:-1]
 
 
-def retry_respond_system_message(history: list) -> list:
+def retry_respond_system_message(x: gr.RetryData, history: list) -> list:
     """Respond to the user message with a system message"""
     history = remove_last_message(history)
     return respond_system_message(history)
@@ -143,7 +143,7 @@ def wrangle_edit_data(x: gr.EditData, history: list) -> list:
         index = x.index[0]
 
     history = history[:index]
-    if history[index]["role"] == "user":
+    if history[-1]["role"] == "user":
         return respond_system_message(history)
     return history
 

--- a/app/app.py
+++ b/app/app.py
@@ -125,10 +125,12 @@ def wrangle_like_data(x: gr.LikeData, history) -> DataFrame:
         elif rating == "disliked":
             message["rating"] = -1
         else:
-            message["rating"] = None
+            message["rating"] = 0
 
         output_data.append(
-            dict([(k, v) for k, v in message.items() if k != "metadata"])
+            dict(
+                [(k, v) for k, v in message.items() if k not in ["metadata", "options"]]
+            )
         )
 
     return history, DataFrame(data=output_data)

--- a/app/app.py
+++ b/app/app.py
@@ -140,8 +140,8 @@ def wrangle_edit_data(x: gr.EditData, history: list) -> list:
     else:
         index = x.index[0]
 
+    history = history[:index]
     if history[index]["role"] == "user":
-        history = history[:index]
         return respond_system_message(history)
     else:
         return history

--- a/app/app.py
+++ b/app/app.py
@@ -143,8 +143,7 @@ def wrangle_edit_data(x: gr.EditData, history: list) -> list:
     history = history[:index]
     if history[index]["role"] == "user":
         return respond_system_message(history)
-    else:
-        return history
+    return history
 
 
 def submit_conversation(dataframe, session_id):

--- a/app/app.py
+++ b/app/app.py
@@ -192,9 +192,7 @@ def wrangle_edit_data(
     original_message = gr.ChatMessage(
         role="assistant", content=dataframe.iloc[index]["content"]
     ).__dict__
-    import pdb
 
-    pdb.set_trace()
     if history[index]["role"] == "user":
         # Add feedback on original and corrected message
         add_fake_like_data(history[: index + 2], session_id, liked=True)


### PR DESCRIPTION
- undo: works nicely to revert a message. We could consider submitting the conversation and submitting it as negative feedback.
- regenerate: works nicely to get another completion. We could consider submitting the initial generation as negative feedback.
- edit: works at the moment, but we only receive event data after the edit, which does not allow for directly getting preference data.

additionally, we can add more logic flows through feedback options
